### PR TITLE
Allow active element selection for REST routing.

### DIFF
--- a/dist/js/sb-admin-2.js
+++ b/dist/js/sb-admin-2.js
@@ -28,7 +28,7 @@ $(function() {
 
     var url = window.location;
     var element = $('ul.nav a').filter(function() {
-        return this.href == url;
+        return this.href == url || url.href.indexOf(this.href) == 0;
     }).addClass('active').parent().parent().addClass('in').parent();
     if (element.is('li')) {
         element.addClass('active');


### PR DESCRIPTION
Given I have REST routing in my web application/dashboard.
I have these items in my sidebar:

```
- Home
- Users
```

When I click on users it routes to `/users` and the menu item will get highlighted. As the name suggests, I get all users displayed. When I now want to view the details of a user, I click on it and I get routed to `/users/the_user`. The problem is, the menu item will no longer be highlighted, even though it should. This PR fixes this behavior.

However, I have no idea how many people rely on how it is working/was working previously.