### PR TITLE
Fix 404 error code and add datatable responsive

### DIFF
--- a/pages/tables.html
+++ b/pages/tables.html
@@ -21,7 +21,7 @@
     <link href="../bower_components/datatables-plugins/integration/bootstrap/3/dataTables.bootstrap.css" rel="stylesheet">
 
     <!-- DataTables Responsive CSS -->
-    <link href="../bower_components/datatables-responsive/css/dataTables.responsive.css" rel="stylesheet">
+    <link href="../bower_components/datatables-responsive/css/responsive.bootstrap.css" rel="stylesheet">
 
     <!-- Custom CSS -->
     <link href="../dist/css/sb-admin-2.css" rel="stylesheet">
@@ -1126,6 +1126,7 @@
 
     <!-- DataTables JavaScript -->
     <script src="../bower_components/datatables/media/js/jquery.dataTables.min.js"></script>
+    <script src="../bower_components/datatables-responsive/js/dataTables.responsive.js"></script>
     <script src="../bower_components/datatables-plugins/integration/bootstrap/3/dataTables.bootstrap.min.js"></script>
 
     <!-- Custom Theme JavaScript -->


### PR DESCRIPTION
- Error 404 on page 'tables' - link to unexisting scss file
- Invalid responsive mode for element '#dataTables-example'

Changes:
- remove link to unexisting scss file
- add link to responsive.bootstrap.css
- add missing script dataTables.responsive.js